### PR TITLE
Fixes an issue that prevented adding new listeners

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,10 +17,11 @@ define(function(require) {
     require('./hbs');
 
     Subscribe = function(channel,object) {
+      //We want to be able to push new listeners into Channels[channel]
       if (!Channels[channel]) {
         Channels[channel] = [];
-        Channels[channel].push(object);
       }
+      Channels[channel].push(object);
     };
     Publish = function(channel,options) {
       if (Channels[channel]) {


### PR DESCRIPTION
We really want to push new listeners into the array if this already exists.
Currently in Crete we're only able to register one single listener
